### PR TITLE
Rename Schmitt trigger function to correct spelling

### DIFF
--- a/src/schmitt_trigger.m
+++ b/src/schmitt_trigger.m
@@ -1,5 +1,5 @@
 %SCHMITT TRIGGER
-function [y] = schmidtt_trigger(x,tL,tH)
+function [y] = schmitt_trigger(x,tL,tH)
 
 %x=rand(1,100);
 %x=conv(x,ones(10,1)/10);


### PR DESCRIPTION
The function for the Schmitt trigger was called `schmidtt_trigger` which is the incorrect spelling. It has been changed to `schmitt_trigger`